### PR TITLE
Feature/add leakage routine

### DIFF
--- a/larpixdaq/routines/leakage.py
+++ b/larpixdaq/routines/leakage.py
@@ -1,0 +1,32 @@
+from routines import Routine
+import copy
+from larpix.larpix import Configuration
+
+def _leakage(controller, send_data, send_info, chip, *args):
+    '''
+    leakage(run_time)
+
+    Measures leakage rate on a given chip by disabling periodic resets. Leakage
+    current can be calculated as (rate_leakage - rate_nom) * threshold where
+    rate_leakage is the trigger rate during this routine, rate_nom is the nominal
+    trigger rate, and threshold is the trigger threshold.
+
+    '''
+    run_time = float(args[0])
+
+    chip_key = chip
+    chip = controller.get_chip(chip_key)
+
+    orig_config = copy.deepcopy(chip.config)
+    chip.config.periodic_reset = 0
+    controller.write_configuration(chip_key, Configuration.periodic_reset_address)
+    controller.run(run_time,message='leakage {}'.format(chip_key))
+    chip.config = orig_config
+    controller.write_configuration(chip_key)
+
+    to_return = 'success'
+    return controller, to_return
+
+leakage = Routine('leakage', _leakage, ['run_time'])
+
+registration = {'leakage': leakage}

--- a/larpixdaq/routines/leakage.py
+++ b/larpixdaq/routines/leakage.py
@@ -2,6 +2,8 @@ from routines import Routine
 import copy
 from larpix.larpix import Configuration
 
+quick_run_time = 0.1
+
 def _leakage(controller, send_data, send_info, chip, *args):
     '''
     leakage(run_time)
@@ -19,8 +21,13 @@ def _leakage(controller, send_data, send_info, chip, *args):
 
     orig_config = copy.deepcopy(chip.config)
     chip.config.periodic_reset = 0
-    controller.write_configuration(chip_key, Configuration.periodic_reset_address)
+    controller.write_configuration(chip_key, Configuration.test_mode_xtrig_reset_diag_address)
+    controller.run(quick_run_time,message='flush queue')
     controller.run(run_time,message='leakage {}'.format(chip_key))
+    packets = list(filter(lambda x: x.chip_key == chip_key, controller.reads[-1]))
+    for channel in range(32):
+        channel_packets = list(filter(lambda x: x.channel_id == channel, packets))
+        send_info('rate {}: {} Hz'.format(channel, len(channel_packets)/run_time))
     chip.config = orig_config
     controller.write_configuration(chip_key)
 


### PR DESCRIPTION
Adds a routine that takes a specified amount of data with the periodic reset disabled. The change in trigger rate can be used to determine the leakage current on a given channel.